### PR TITLE
Make GXWGFifo volatile

### DIFF
--- a/include/dolphin/gx/GXVert.h
+++ b/include/dolphin/gx/GXVert.h
@@ -23,7 +23,7 @@ typedef union {
 } PPCWGPipe;
 
 #ifdef __MWERKS__
-/*volatile*/ PPCWGPipe GXWGFifo : GXFIFO_ADDR;
+volatile PPCWGPipe GXWGFifo : GXFIFO_ADDR;
 #else
 #define GXWGFifo (*(volatile PPCWGPipe*)GXFIFO_ADDR)
 #endif


### PR DESCRIPTION
Will fix fn_1_5C2C in m440Dll/main.c